### PR TITLE
fix: Fix local files with UTF8 names

### DIFF
--- a/packager/file/file.cc
+++ b/packager/file/file.cc
@@ -73,8 +73,8 @@ bool DeleteLocalFile(const char* file_name) {
 
 bool WriteLocalFileAtomically(const char* file_name,
                               const std::string& contents) {
-  const std::filesystem::path file_path(file_name);
-  const std::filesystem::path dir_path = file_path.parent_path();
+  const auto file_path = std::filesystem::u8path(file_name);
+  const auto dir_path = file_path.parent_path();
 
   std::string temp_file_name;
   if (!TempFilePath(dir_path.string(), &temp_file_name))
@@ -83,7 +83,8 @@ bool WriteLocalFileAtomically(const char* file_name,
     return false;
 
   std::error_code ec;
-  std::filesystem::rename(temp_file_name, file_name, ec);
+  auto temp_file_path = std::filesystem::u8path(temp_file_name);
+  std::filesystem::rename(temp_file_path, file_name, ec);
   if (ec) {
     LOG(ERROR) << "Failed to replace file '" << file_name << "' with '"
                << temp_file_name << "', error: " << ec;
@@ -405,7 +406,8 @@ bool File::IsLocalRegularFile(const char* file_name) {
     return false;
 
   std::error_code ec;
-  return std::filesystem::is_regular_file(real_file_name, ec);
+  auto real_file_path = std::filesystem::u8path(real_file_name);
+  return std::filesystem::is_regular_file(real_file_path, ec);
 }
 
 std::string File::MakeCallbackFileName(

--- a/packager/file/file_test_util.cc
+++ b/packager/file/file_test_util.cc
@@ -16,8 +16,8 @@ std::string generate_unique_temp_path() {
   // Generate a unique name for a temporary file, using standard library
   // routines, to avoid a circular dependency on any of our own code for
   // generating temporary files.  The template must end in 6 X's.
-  std::filesystem::path temp_path_template =
-      (std::filesystem::temp_directory_path() / "packager-test.XXXXXX");
+  auto temp_path_template =
+      std::filesystem::temp_directory_path() / "packager-test.XXXXXX";
   std::string temp_path_template_string = temp_path_template.string();
 #if defined(OS_WIN)
   // _mktemp will modify the string passed to it to reflect the generated name
@@ -36,7 +36,7 @@ std::string generate_unique_temp_path() {
 
 void delete_file(const std::string& path) {
   std::error_code ec;
-  std::filesystem::remove(path, ec);
+  std::filesystem::remove(std::filesystem::u8path(path), ec);
   // Ignore errors.
 }
 
@@ -44,7 +44,7 @@ TempFile::TempFile() : path_(generate_unique_temp_path()) {}
 
 TempFile::~TempFile() {
   std::error_code ec;
-  std::filesystem::remove(path_, ec);
+  std::filesystem::remove(std::filesystem::u8path(path_), ec);
   // Ignore errors.
 }
 

--- a/packager/file/file_util.cc
+++ b/packager/file/file_util.cc
@@ -43,7 +43,7 @@ std::string TempFileName() {
 }  // namespace
 
 bool TempFilePath(const std::string& temp_dir, std::string* temp_file_path) {
-  std::filesystem::path temp_dir_path(temp_dir);
+  auto temp_dir_path = std::filesystem::u8path(temp_dir);
   *temp_file_path = (temp_dir_path / TempFileName()).string();
   return true;
 }

--- a/packager/file/local_file.cc
+++ b/packager/file/local_file.cc
@@ -75,7 +75,8 @@ int64_t LocalFile::Size() {
   }
 
   std::error_code ec;
-  int64_t file_size = std::filesystem::file_size(file_name(), ec);
+  auto file_path = std::filesystem::u8path(file_name());
+  int64_t file_size = std::filesystem::file_size(file_path, ec);
   if (ec) {
     LOG(ERROR) << "Cannot get file size, error: " << ec;
     return -1;
@@ -112,7 +113,7 @@ bool LocalFile::Tell(uint64_t* position) {
 LocalFile::~LocalFile() {}
 
 bool LocalFile::Open() {
-  std::filesystem::path file_path(file_name());
+  auto file_path = std::filesystem::u8path(file_name());
 
   // Create upper level directories for write mode.
   if (file_mode_.find("w") != std::string::npos) {
@@ -133,9 +134,10 @@ bool LocalFile::Open() {
 }
 
 bool LocalFile::Delete(const char* file_name) {
+  auto file_path = std::filesystem::u8path(file_name);
   std::error_code ec;
   // On error (ec truthy), remove() will return false anyway.
-  return std::filesystem::remove(file_name, ec);
+  return std::filesystem::remove(file_path, ec);
 }
 
 }  // namespace shaka

--- a/packager/media/base/container_names_unittest.cc
+++ b/packager/media/base/container_names_unittest.cc
@@ -144,7 +144,7 @@ TEST(ContainerNamesTest, CheckFixedStrings) {
 
 // Determine the container type of a specified file.
 void TestFile(MediaContainerName expected, const std::string& name) {
-  std::filesystem::path path = GetTestDataFilePath(name);
+  auto path = GetTestDataFilePath(name);
   std::vector<uint8_t> data = ReadTestDataFile(name);
   ASSERT_FALSE(data.empty());
 

--- a/packager/media/test/test_data_util.cc
+++ b/packager/media/test/test_data_util.cc
@@ -11,13 +11,13 @@ namespace media {
 
 // Returns a file path for a file in the media/test/data directory.
 std::filesystem::path GetTestDataFilePath(const std::string& name) {
-  std::filesystem::path data_dir(TEST_DATA_DIR);
+  auto data_dir = std::filesystem::u8path(TEST_DATA_DIR);
   return data_dir / name;
 }
 
 // Returns a file path for a file in the media/app/test/testdata directory.
 std::filesystem::path GetAppTestDataFilePath(const std::string& name) {
-  std::filesystem::path data_dir(TEST_DATA_DIR);
+  auto data_dir = std::filesystem::u8path(TEST_DATA_DIR);
   auto app_data_dir =
       data_dir.parent_path().parent_path() / "app" / "test" / "testdata";
   return app_data_dir / name;
@@ -25,7 +25,7 @@ std::filesystem::path GetAppTestDataFilePath(const std::string& name) {
 
 // Reads a test file from media/test/data directory and returns its content.
 std::vector<uint8_t> ReadTestDataFile(const std::string& name) {
-  std::filesystem::path path = GetTestDataFilePath(name);
+  auto path = GetTestDataFilePath(name);
 
   FILE* f = fopen(path.string().c_str(), "rb");
   if (!f) {


### PR DESCRIPTION
This fixes our use of std::filesystem to interpret all paths names as UTF8.  Before this, UTF8 paths on Windows did not work correctly.

This also adds a new unit test to cover this case.

Closes #652